### PR TITLE
Use overrideCracoConfig

### DIFF
--- a/lib/craco-antd.js
+++ b/lib/craco-antd.js
@@ -14,16 +14,16 @@ module.exports = {
       lessLoaderOptions
     });
 
-    const { getLoader, loaderByName } = require("@craco/craco");
-    const { match: babelLoaderMatch } = getLoader(
-      webpackConfig,
-      loaderByName("babel-loader")
-    );
-    babelLoaderMatch.loader.options.plugins.unshift([
+    return newWebpackConfig;
+  },
+  overrideCracoConfig: ({ cracoConfig }) => {
+    const { babel: { plugins = [] } = {} } = cracoConfig;
+    
+    plugins.push([
       "import",
       { libraryName: "antd", libraryDirectory: "es", style: "css" }
     ]);
 
-    return newWebpackConfig;
+    return cracoConfig;
   }
 };


### PR DESCRIPTION
You don't need to merge it, I wanted to show you that you could also use `overrideCracoConfig` to add a babel plugin